### PR TITLE
feat(frontend): add reusable data query hooks (#118)

### DIFF
--- a/src/app/(dashboard)/artisan/listings/(components)/AppliedJobsList.tsx
+++ b/src/app/(dashboard)/artisan/listings/(components)/AppliedJobsList.tsx
@@ -1,43 +1,34 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Image from "next/image";
 import bgImg from "../(assets)/bg.png";
+import { useApplications } from "@/lib/hooks";
 
-interface Application {
-  id: string;
-  jobId: string;
-  jobTitle: string;
-  company: string;
-  state: string;
-  appliedAt: string;
-  updatedAt: string;
-}
+const formatDate = (value: string) =>
+  value ? new Date(value).toLocaleDateString() : "—";
+
+const formatDateTime = (value: string) =>
+  value ? new Date(value).toLocaleString() : "—";
 
 const AppliedJobsList = () => {
-  const [applications, setApplications] = useState<Application[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { applications, isLoading, error, refetch } = useApplications();
 
-  useEffect(() => {
-    const fetchApplications = async () => {
-      try {
-        const response = await fetch("/api/applications");
-        if (response.ok) {
-          const data = await response.json();
-          setApplications(data.applications || []);
-        }
-      } catch (error) {
-        console.error("Failed to fetch applications:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchApplications();
-  }, []);
-
-  if (loading) {
+  if (isLoading) {
     return <div className="py-10 text-center text-sm text-gray-500">Loading applications...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="py-10 text-center">
+        <p className="text-sm text-red-600">{error}</p>
+        <button
+          onClick={() => refetch()}
+          className="mt-3 px-4 py-2 text-sm border rounded-md hover:bg-gray-50"
+        >
+          Try again
+        </button>
+      </div>
+    );
   }
 
   if (applications.length === 0) {
@@ -62,12 +53,12 @@ const AppliedJobsList = () => {
             <div className="flex lg:justify-between lg:items-center md:justify-between md:items-center lg:flex-row md:flex-row flex-col">
               <div>
                 <p className="text-[12px] text-[#212121]">
-                  Applied: {new Date(app.appliedAt).toLocaleDateString()}
+                  Applied: {formatDate(app.appliedAt)}
                 </p>
                 <h2 className="lg:text-[20px] md:text-[18px] text-[16px] font-semibold">
                   {app.jobTitle}
                 </h2>
-                <p className="text-[14px] text-gray-600 mt-1">{app.company}</p>
+                <p className="text-[14px] text-gray-600 mt-1">{app.company || app.location}</p>
               </div>
               
               <div className="lg:my-0 md:my-0 my-3">
@@ -85,7 +76,7 @@ const AppliedJobsList = () => {
 
             <div className="text-[12px] text-[#777679] mt-auto pt-4 flex flex-col lg:flex-row md:flex-row">
               <p>
-                Last updated: {new Date(app.updatedAt).toLocaleString()}
+                Last updated: {formatDateTime(app.updatedAt)}
               </p>
             </div>
           </div>

--- a/src/app/(dashboard)/artisan/listings/(components)/CompletedJobsList.tsx
+++ b/src/app/(dashboard)/artisan/listings/(components)/CompletedJobsList.tsx
@@ -1,46 +1,30 @@
 "use client";
 
-import { useEffect, useState } from "react";
-
-interface CompletedJob {
-  id: string;
-  title: string;
-  category: string;
-  compensation: string;
-  location: string;
-  completedAt: string;
-  clientName: string;
-}
+import type { CompletedJob } from "@/lib/api/jobs";
+import { useJobs } from "@/lib/hooks";
 
 const LIMIT = 5;
 
 const CompletedJobsList = () => {
-  const [jobs, setJobs] = useState<CompletedJob[]>([]);
-  const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const [loading, setLoading] = useState(true);
+  const { jobs, isLoading, error, page, totalPages, setPage, refetch } =
+    useJobs<CompletedJob>({ status: "completed", limit: LIMIT });
 
-  useEffect(() => {
-    const fetchJobs = async () => {
-      setLoading(true);
-      try {
-        const res = await fetch(`/api/jobs?page=${page}&limit=${LIMIT}`);
-        if (res.ok) {
-          const data = await res.json();
-          setJobs(data.jobs ?? []);
-          setTotalPages(data.totalPages ?? 1);
-        }
-      } catch (error) {
-        console.error("Failed to fetch completed jobs:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchJobs();
-  }, [page]);
-
-  if (loading) {
+  if (isLoading) {
     return <div className="py-10 text-center text-sm text-gray-500">Loading completed jobs...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="py-10 text-center">
+        <p className="text-sm text-red-600">{error}</p>
+        <button
+          onClick={() => refetch()}
+          className="mt-3 px-4 py-2 text-sm border rounded-md hover:bg-gray-50"
+        >
+          Try again
+        </button>
+      </div>
+    );
   }
 
   if (jobs.length === 0) {
@@ -76,7 +60,7 @@ const CompletedJobsList = () => {
       {totalPages > 1 && (
         <div className="flex justify-center items-center gap-4 mt-6">
           <button
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            onClick={() => setPage(page - 1)}
             disabled={page === 1}
             className="px-4 py-2 text-sm border rounded-md disabled:opacity-40 hover:bg-gray-50"
           >
@@ -86,7 +70,7 @@ const CompletedJobsList = () => {
             Page {page} of {totalPages}
           </span>
           <button
-            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            onClick={() => setPage(Math.min(totalPages, page + 1))}
             disabled={page === totalPages}
             className="px-4 py-2 text-sm border rounded-md disabled:opacity-40 hover:bg-gray-50"
           >

--- a/src/app/(dashboard)/artisan/listings/(components)/JobCard.tsx
+++ b/src/app/(dashboard)/artisan/listings/(components)/JobCard.tsx
@@ -1,127 +1,105 @@
 'use client';
 
-import { Suspense, useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useMemo, useState } from 'react';
 
 import Image from 'next/image';
-import type { Job } from '../dummyjobs';
+import { ApplicationRequestError } from '@/lib/api/applications';
+import type { AvailableJob } from '@/lib/api/jobs';
 import JobFilter from './JobFilters';
 import Link from 'next/link';
 import bgImg from '../(assets)/bg.png';
+import { useApplications, useJobs } from '@/lib/hooks';
 import { useWallet } from '@/context/WalletProvider';
 
+type Filters = {
+  search: string;
+  role: string | null;
+  urgency: string | null;
+};
+
+type ApplyStatus = {
+  state: 'loading' | 'success' | 'duplicate' | 'error';
+  message?: string;
+};
+
+const NO_FILTERS: Filters = { search: '', role: null, urgency: null };
+
 const JobCard = () => {
-  const [jobs, setJobs] = useState<Job[]>([]);
-  const [filteredJobs, setFilteredJobs] = useState<Job[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const { jobs, isLoading, error, refetch } = useJobs<AvailableJob>({
+    status: 'available',
+  });
+  // The listing only needs the mutation, so the applications request is skipped.
+  const { createApplication } = useApplications({ enabled: false });
   const { publicKey, connected } = useWallet();
-  const [_, setStatusMap] = useState<
-    Record<number, { state: string; message?: string }>
-  >({});
 
-  useEffect(() => {
-    const controller = new AbortController();
-    fetch('/api/jobs?status=available', { signal: controller.signal })
-      .then((response) => {
-        if (!response.ok) throw new Error('Unable to load available jobs');
-        return response.json() as Promise<{ jobs: Job[] }>;
-      })
-      .then(({ jobs: availableJobs }) => {
-        setJobs(availableJobs);
-        setFilteredJobs(availableJobs);
-      })
-      .catch((error: unknown) => {
-        if (!(error instanceof Error && error.name === 'AbortError')) {
-          setJobs([]);
-          setFilteredJobs([]);
-        }
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setIsLoading(false);
-      });
-    return () => controller.abort();
-  }, []);
+  const [filters, setFilters] = useState<Filters>(NO_FILTERS);
+  const [statusMap, setStatusMap] = useState<Record<string, ApplyStatus>>({});
 
-  const applyToJob = async (job: Job, idx: number) => {
+  const applyToJob = async (job: AvailableJob) => {
     if (!connected || !publicKey) {
       setStatusMap((s) => ({
         ...s,
-        [idx]: { state: 'error', message: 'Connect your wallet to apply.' },
+        [job.id]: { state: 'error', message: 'Connect your wallet to apply.' },
       }));
       return;
     }
 
-    setStatusMap((s) => ({ ...s, [idx]: { state: 'loading' } }));
+    setStatusMap((s) => ({ ...s, [job.id]: { state: 'loading' } }));
 
     try {
-      const payload = {
+      await createApplication({
+        jobId: job.id,
         jobTitle: job.title,
         jobShortDescription: job.shortDescription,
         location: job.location,
         applicant: publicKey,
-      };
-
-      const res = await fetch('/api/applications', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
       });
-
-      if (res.status === 201) {
-        setStatusMap((s) => ({
-          ...s,
-          [idx]: { state: 'success', message: 'Application submitted.' },
-        }));
-      } else if (res.status === 409) {
-        setStatusMap((s) => ({
-          ...s,
-          [idx]: { state: 'duplicate', message: 'You have already applied.' },
-        }));
-      } else {
-        const data = await res.json().catch(() => ({}));
-        setStatusMap((s) => ({
-          ...s,
-          [idx]: {
-            state: 'error',
-            message: data?.message || 'Failed to submit application.',
-          },
-        }));
-      }
-    } catch {
       setStatusMap((s) => ({
         ...s,
-        [idx]: { state: 'error', message: 'Network error.' },
+        [job.id]: { state: 'success', message: 'Application submitted.' },
+      }));
+    } catch (err) {
+      const duplicate =
+        err instanceof ApplicationRequestError && err.code === 'duplicate';
+      setStatusMap((s) => ({
+        ...s,
+        [job.id]: {
+          state: duplicate ? 'duplicate' : 'error',
+          message:
+            err instanceof Error
+              ? err.message
+              : 'Failed to submit application.',
+        },
       }));
     }
   };
 
-  void applyToJob;
+  const handleFilterChange = useCallback((next: Filters) => {
+    setFilters(next);
+  }, []);
 
-  const handleFilterChange = useCallback(
-    (filters: {
-      search: string;
-      role: string | null;
-      urgency: string | null;
-    }) => {
-      const result = jobs.filter((job) => {
-        const matchesSearch =
-          job.title.toLowerCase().includes(filters.search.toLowerCase()) ||
-          job.shortDescription
-            .toLowerCase()
-            .includes(filters.search.toLowerCase());
+  const filteredJobs = useMemo(() => {
+    const search = filters.search.toLowerCase();
 
-        const matchesRole = filters.role
-          ? job.title.toLowerCase().includes(filters.role.toLowerCase())
-          : true;
+    return jobs.filter((job) => {
+      const matchesSearch =
+        job.title.toLowerCase().includes(search) ||
+        job.shortDescription.toLowerCase().includes(search);
 
-        const matchesUrgency = filters.urgency
-          ? job.urgency === filters.urgency
-          : true;
+      const matchesRole = filters.role
+        ? job.title.toLowerCase().includes(filters.role.toLowerCase())
+        : true;
 
-        return matchesSearch && matchesRole && matchesUrgency;
-      });
+      const matchesUrgency = filters.urgency
+        ? job.urgency === filters.urgency
+        : true;
 
-      setFilteredJobs(result);
-    },
+      return matchesSearch && matchesRole && matchesUrgency;
+    });
+  }, [jobs, filters]);
+
+  const roles = useMemo(
+    () => Array.from(new Set(jobs.map((job) => job.title))),
     [jobs],
   );
 
@@ -133,72 +111,106 @@ const JobCard = () => {
           <div className="text-sm text-gray-400">Loading filters...</div>
         }
       >
-        <JobFilter onFilterChange={handleFilterChange} roles={Array.from(new Set(jobs.map((job) => job.title)))} />
+        <JobFilter onFilterChange={handleFilterChange} roles={roles} />
       </Suspense>
 
       {isLoading && <p className="mt-8 text-sm text-gray-400">Loading available jobs...</p>}
-      <div className="mt-8">
-        {filteredJobs.map((info, index) => (
-          <div
-            key={index}
-            className="flex mb-4 lg:flex-row md:flex-row flex-col"
+
+      {error && (
+        <div className="mt-8">
+          <p className="text-sm text-red-600">{error}</p>
+          <button
+            onClick={() => refetch()}
+            className="mt-3 px-4 py-2 text-sm border rounded-md hover:bg-gray-50"
           >
-            <div className="lg:w-[12%] md:w-[20%] w-full lg:mr-6 md:mr-4 mr-0">
-              <Image
-                src={bgImg}
-                alt=""
-                width={200}
-                height={200}
-                className="w-full"
-              />
-            </div>
+            Try again
+          </button>
+        </div>
+      )}
 
-            <div className="lg:w-[70%] md:w-[70%] w-full flex flex-col lg:my-0 md:my-0 my-3">
-              <div className="flex flex-col gap-3 lg:flex-row lg:justify-between lg:items-center md:flex-row md:justify-between md:items-center">
-                <div>
-                  <p className="text-[12px] text-[#212121]">
-                    Posted 2 mins ago
+      <div className="mt-8">
+        {filteredJobs.map((info) => {
+          const status = statusMap[info.id];
+
+          return (
+            <div
+              key={info.id}
+              className="flex mb-4 lg:flex-row md:flex-row flex-col"
+            >
+              <div className="lg:w-[12%] md:w-[20%] w-full lg:mr-6 md:mr-4 mr-0">
+                <Image
+                  src={bgImg}
+                  alt=""
+                  width={200}
+                  height={200}
+                  className="w-full"
+                />
+              </div>
+
+              <div className="lg:w-[70%] md:w-[70%] w-full flex flex-col lg:my-0 md:my-0 my-3">
+                <div className="flex flex-col gap-3 lg:flex-row lg:justify-between lg:items-center md:flex-row md:justify-between md:items-center">
+                  <div>
+                    <p className="text-[12px] text-[#212121]">
+                      Posted 2 mins ago
+                    </p>
+                    <h2 className="lg:text-[20px] md:text-[18px] text-[16px] font-semibold">
+                      {info.shortDescription}
+                    </h2>
+                  </div>
+                  <div className="flex flex-col sm:flex-row gap-3">
+                    <Link
+                      href={`/artisan/jobs/${info.id}`}
+                      className="text-sm font-medium text-[#605DEC] hover:underline"
+                    >
+                      View details
+                    </Link>
+                    <button
+                      onClick={() => applyToJob(info)}
+                      disabled={status?.state === 'loading'}
+                      className="border rounded-md py-2 hover:bg-black hover:text-white text-[14px] px-6 disabled:opacity-60 disabled:cursor-not-allowed"
+                    >
+                      {status?.state === 'loading' ? 'Applying...' : 'Apply'}
+                    </button>
+                  </div>
+                </div>
+
+                {status?.message && (
+                  <p
+                    className={`text-[12px] mt-2 ${
+                      status.state === 'success'
+                        ? 'text-green-600'
+                        : status.state === 'duplicate'
+                          ? 'text-yellow-600'
+                          : 'text-red-600'
+                    }`}
+                  >
+                    {status.message}
                   </p>
-                  <h2 className="lg:text-[20px] md:text-[18px] text-[16px] font-semibold">
-                    {info.shortDescription}
-                  </h2>
-                </div>
-                <div className="flex flex-col sm:flex-row gap-3">
-                  <Link
-                    href={`/artisan/jobs/${info.id}`}
-                    className="text-sm font-medium text-[#605DEC] hover:underline"
-                  >
-                    View details
-                  </Link>
-                  <button
-                    onClick={() => alert('Application sent!')}
-                    className="border rounded-md py-2 hover:bg-black hover:text-white text-[14px] px-6"
-                  >
-                    Apply
-                  </button>
-                </div>
-              </div>
+                )}
 
-              <div className="text-[14px] flex justify-between lg:items-center md:items-center mt-auto text-[#777679] flex-col lg:flex-row md:flex-row">
-                <p>
-                  Category: {info.category} <span className="mx-4">|</span>
-                </p>
-                <p>
-                  Compensation: {info.budget} <span className="mx-4">|</span>
-                </p>
-                <p>
-                  Location: {info.location} <span className="mx-4">|</span>
-                </p>
-                <p>
-                  Urgency:{' '}
-                  <span className="uppercase text-red-500">{info.urgency}</span>
-                </p>
+                <div className="text-[14px] flex justify-between lg:items-center md:items-center mt-auto text-[#777679] flex-col lg:flex-row md:flex-row">
+                  <p>
+                    Category: {info.category} <span className="mx-4">|</span>
+                  </p>
+                  <p>
+                    Compensation: {info.budget} <span className="mx-4">|</span>
+                  </p>
+                  <p>
+                    Location: {info.location} <span className="mx-4">|</span>
+                  </p>
+                  <p>
+                    Urgency:{' '}
+                    <span className="uppercase text-red-500">
+                      {info.urgency}
+                    </span>
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
 
-        {filteredJobs.length === 0 && (
+        {!isLoading && !error && filteredJobs.length === 0 && (
           <p className="text-center text-gray-500 mt-10">
             No jobs match your filters
           </p>

--- a/src/app/(dashboard)/artisan/profile/page.tsx
+++ b/src/app/(dashboard)/artisan/profile/page.tsx
@@ -10,8 +10,10 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
+import { EMPTY_ARTISAN_PROFILE, type ArtisanProfile } from '@/lib/api/profile';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { useProfile } from '@/lib/hooks';
 
 const skillCategories = [
   'Carpentry',
@@ -47,34 +49,30 @@ const experienceOptions = [
   '10+ years',
 ];
 
-interface ProfileData {
-  fullName: string;
-  email: string;
-  skillCategory: string;
-  state: string;
-  city: string;
-  yearsOfExperience: string;
-  bio: string;
-  profileImageUrl: string | null;
-}
-
 export default function ArtisanProfilePage() {
+  const {
+    profile,
+    isLoading,
+    error,
+    refetch,
+    updateProfile,
+    isSaving,
+    saveError,
+  } = useProfile();
+
   const [_, setProfileImageFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const [formData, setFormData] = useState<ProfileData>({
-    fullName: 'Samuel Adeyemi',
-    email: 'samuel@example.com',
-    skillCategory: 'Carpentry',
-    state: 'Lagos',
-    city: 'Ikeja',
-    yearsOfExperience: '5-10 years',
-    bio: "I'm a skilled carpenter with over 7 years of experience in custom furniture, cabinetry, and general woodwork. I take pride in delivering quality craftsmanship that meets clients' exact specifications and timelines.",
-    profileImageUrl: null,
-  });
+  // Unsaved edits live in `draft`; until the user types, the form renders the
+  // profile returned by the hook.
+  const [draft, setDraft] = useState<ArtisanProfile | null>(null);
+  const formData = draft ?? profile ?? EMPTY_ARTISAN_PROFILE;
+
+  const updateField = (changes: Partial<ArtisanProfile>) => {
+    setDraft({ ...formData, ...changes });
+  };
 
   const mockStats = {
     profileViews: 124,
@@ -91,16 +89,19 @@ export default function ArtisanProfilePage() {
     }
   };
 
-  const handleSave = (e: React.FormEvent) => {
+  const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
-    setIsSaving(true);
     setSaveSuccess(false);
-    // Simulate API call
-    setTimeout(() => {
-      setIsSaving(false);
+
+    try {
+      await updateProfile(formData);
+      // Fall back to the stored profile now that the draft is persisted.
+      setDraft(null);
       setSaveSuccess(true);
       setTimeout(() => setSaveSuccess(false), 3000);
-    }, 1000);
+    } catch {
+      // The hook exposes the failure through `saveError`.
+    }
   };
 
   const displayImage = previewUrl ?? formData.profileImageUrl;
@@ -117,6 +118,29 @@ export default function ArtisanProfilePage() {
     (completionItems.filter((i) => i.done).length / completionItems.length) *
       100,
   );
+
+  if (isLoading && !profile) {
+    return (
+      <div className="w-full py-20 text-center text-sm text-gray-500">
+        Loading your profile...
+      </div>
+    );
+  }
+
+  if (error && !profile) {
+    return (
+      <div className="w-full py-20 text-center">
+        <p className="text-sm text-red-600">{error}</p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="mt-3 px-4 py-2 text-sm border rounded-md hover:bg-gray-50"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="w-full">
@@ -227,7 +251,7 @@ export default function ArtisanProfilePage() {
                     id="fullName"
                     value={formData.fullName}
                     onChange={(e) =>
-                      setFormData({ ...formData, fullName: e.target.value })
+                      updateField({ fullName: e.target.value })
                     }
                     placeholder="Your full name"
                     className="h-10 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[#605DEC]"
@@ -242,7 +266,7 @@ export default function ArtisanProfilePage() {
                     type="email"
                     value={formData.email}
                     onChange={(e) =>
-                      setFormData({ ...formData, email: e.target.value })
+                      updateField({ email: e.target.value })
                     }
                     placeholder="you@example.com"
                     className="h-10 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[#605DEC]"
@@ -257,7 +281,7 @@ export default function ArtisanProfilePage() {
                 <Select
                   value={formData.skillCategory}
                   onValueChange={(value) =>
-                    setFormData({ ...formData, skillCategory: value })
+                    updateField({ skillCategory: value })
                   }
                 >
                   <SelectTrigger className="h-10 focus:ring-0 focus:ring-offset-0 focus:border-[#605DEC]">
@@ -284,7 +308,7 @@ export default function ArtisanProfilePage() {
                 <Select
                   value={formData.yearsOfExperience}
                   onValueChange={(value) =>
-                    setFormData({ ...formData, yearsOfExperience: value })
+                    updateField({ yearsOfExperience: value })
                   }
                 >
                   <SelectTrigger className="h-10 focus:ring-0 focus:ring-offset-0 focus:border-[#605DEC]">
@@ -318,7 +342,7 @@ export default function ArtisanProfilePage() {
                   <Select
                     value={formData.state}
                     onValueChange={(value) =>
-                      setFormData({ ...formData, state: value })
+                      updateField({ state: value })
                     }
                   >
                     <SelectTrigger className="h-10 focus:ring-0 focus:ring-offset-0 focus:border-[#605DEC]">
@@ -345,7 +369,7 @@ export default function ArtisanProfilePage() {
                     id="city"
                     value={formData.city}
                     onChange={(e) =>
-                      setFormData({ ...formData, city: e.target.value })
+                      updateField({ city: e.target.value })
                     }
                     placeholder="Enter your city"
                     className="h-10 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[#605DEC]"
@@ -370,7 +394,7 @@ export default function ArtisanProfilePage() {
                 id="bio"
                 value={formData.bio}
                 onChange={(e) =>
-                  setFormData({ ...formData, bio: e.target.value })
+                  updateField({ bio: e.target.value })
                 }
                 placeholder="Describe your skills, experience, and the type of work you do."
                 rows={5}
@@ -428,6 +452,9 @@ export default function ArtisanProfilePage() {
               <p className="text-sm text-green-600 font-medium">
                 Profile updated successfully.
               </p>
+            )}
+            {saveError && (
+              <p className="text-sm text-red-600 font-medium">{saveError}</p>
             )}
           </div>
         </form>

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+interface ArtisanProfile {
+  fullName: string;
+  email: string;
+  skillCategory: string;
+  state: string;
+  city: string;
+  yearsOfExperience: string;
+  bio: string;
+  profileImageUrl: string | null;
+}
+
+const DEFAULT_PROFILE: ArtisanProfile = {
+  fullName: 'Samuel Adeyemi',
+  email: 'samuel@example.com',
+  skillCategory: 'Carpentry',
+  state: 'Lagos',
+  city: 'Ikeja',
+  yearsOfExperience: '5-10 years',
+  bio: "I'm a skilled carpenter with over 7 years of experience in custom furniture, cabinetry, and general woodwork. I take pride in delivering quality craftsmanship that meets clients' exact specifications and timelines.",
+  profileImageUrl: null,
+};
+
+const COOKIE_NAME = 'artisan-profile';
+
+const TEXT_FIELDS = [
+  'fullName',
+  'email',
+  'skillCategory',
+  'state',
+  'city',
+  'yearsOfExperience',
+  'bio',
+] as const;
+
+/** Keeps only known profile fields so unexpected payload keys are ignored. */
+function sanitizeProfile(body: unknown): Partial<ArtisanProfile> {
+  if (typeof body !== 'object' || body === null) {
+    return {};
+  }
+
+  const record = body as Record<string, unknown>;
+  const changes: Partial<ArtisanProfile> = {};
+
+  for (const field of TEXT_FIELDS) {
+    if (typeof record[field] === 'string') {
+      changes[field] = record[field] as string;
+    }
+  }
+
+  if (typeof record.profileImageUrl === 'string') {
+    changes.profileImageUrl = record.profileImageUrl;
+  } else if (record.profileImageUrl === null) {
+    changes.profileImageUrl = null;
+  }
+
+  return changes;
+}
+
+async function readProfile(): Promise<ArtisanProfile> {
+  const cookieStore = await cookies();
+  const stored = cookieStore.get(COOKIE_NAME)?.value;
+
+  if (!stored) {
+    return DEFAULT_PROFILE;
+  }
+
+  try {
+    return { ...DEFAULT_PROFILE, ...sanitizeProfile(JSON.parse(stored)) };
+  } catch {
+    return DEFAULT_PROFILE;
+  }
+}
+
+async function writeProfile(profile: ArtisanProfile) {
+  const cookieStore = await cookies();
+  cookieStore.set(COOKIE_NAME, JSON.stringify(profile), {
+    path: '/',
+    maxAge: 60 * 60 * 24 * 365, // 1 year
+    httpOnly: false,
+    sameSite: 'lax',
+  });
+}
+
+// GET /api/profile
+export async function GET() {
+  return NextResponse.json(await readProfile());
+}
+
+// PUT /api/profile — merges the provided fields into the stored profile.
+export async function PUT(request: NextRequest) {
+  try {
+    const changes = sanitizeProfile(await request.json());
+    const profile = { ...(await readProfile()), ...changes };
+    await writeProfile(profile);
+    return NextResponse.json(profile);
+  } catch {
+    return NextResponse.json(
+      { message: 'Failed to update profile' },
+      { status: 500 },
+    );
+  }
+}
+
+// POST /api/profile — used by the onboarding flows, same merge semantics.
+export async function POST(request: NextRequest) {
+  return PUT(request);
+}

--- a/src/lib/api/applications.ts
+++ b/src/lib/api/applications.ts
@@ -1,0 +1,175 @@
+/**
+ * Applications API service
+ * Typed access to the job application endpoints.
+ *
+ * The endpoint stores submissions as loosely typed records, so responses are
+ * normalised here to keep a single predictable shape in the UI.
+ */
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+
+export const APPLICATION_STATES = [
+  'Applied',
+  'In Review',
+  'Interviewing',
+  'Accepted',
+  'Rejected',
+  'Withdrawn',
+] as const;
+
+export type ApplicationState = (typeof APPLICATION_STATES)[number];
+
+export interface Application {
+  id: string;
+  jobId: string;
+  jobTitle: string;
+  applicant: string;
+  company: string;
+  location: string;
+  state: ApplicationState;
+  appliedAt: string;
+  updatedAt: string;
+}
+
+export interface CreateApplicationInput {
+  jobTitle: string;
+  applicant: string;
+  jobId?: string;
+  jobShortDescription?: string;
+  location?: string;
+  company?: string;
+}
+
+export type ApplicationErrorCode = 'invalid' | 'duplicate' | 'request';
+
+/** Error thrown by {@link createApplication} with a machine-readable code. */
+export class ApplicationRequestError extends Error {
+  readonly code: ApplicationErrorCode;
+  readonly status: number;
+
+  constructor(message: string, code: ApplicationErrorCode, status: number) {
+    super(message);
+    this.name = 'ApplicationRequestError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+function toRecord(value: unknown): UnknownRecord {
+  return typeof value === 'object' && value !== null
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function firstString(...candidates: unknown[]): string {
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim() !== '') {
+      return candidate;
+    }
+  }
+  return '';
+}
+
+function toApplicationState(value: unknown): ApplicationState {
+  return APPLICATION_STATES.find((state) => state === value) ?? 'Applied';
+}
+
+/** Maps a raw API record onto the {@link Application} shape used by the UI. */
+export function normalizeApplication(raw: unknown): Application {
+  const record = toRecord(raw);
+  const payload = toRecord(record.payload);
+  const appliedAt = firstString(record.createdAt, payload.appliedAt);
+
+  return {
+    id: firstString(record.id, payload.id),
+    jobId: firstString(record.jobId, payload.jobId),
+    jobTitle: firstString(record.jobTitle, payload.jobTitle),
+    applicant: firstString(record.applicant, payload.applicant),
+    company: firstString(record.company, payload.company, payload.clientName),
+    location: firstString(record.location, payload.location),
+    state: toApplicationState(record.state ?? payload.state),
+    appliedAt,
+    updatedAt: firstString(record.updatedAt, payload.updatedAt) || appliedAt,
+  };
+}
+
+function toApplicationList(json: unknown): Application[] {
+  if (Array.isArray(json)) {
+    return json.map(normalizeApplication);
+  }
+
+  const nested = toRecord(json).applications;
+  return Array.isArray(nested) ? nested.map(normalizeApplication) : [];
+}
+
+async function readMessage(res: Response, fallback: string): Promise<string> {
+  const body = await res.json().catch(() => null);
+  return firstString(toRecord(body).message) || fallback;
+}
+
+/** Fetches every application submitted by the current artisan. */
+export async function fetchApplications(
+  signal?: AbortSignal,
+): Promise<Application[]> {
+  const res = await fetch(`${API_BASE_URL}/api/applications`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    cache: 'no-store',
+    signal,
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch applications: ${res.status} ${res.statusText}`,
+    );
+  }
+
+  return toApplicationList(await res.json());
+}
+
+/**
+ * Submits an application for a job.
+ * Throws an {@link ApplicationRequestError} when the endpoint rejects it, so
+ * callers can tell a duplicate apart from a validation or server failure.
+ */
+export async function createApplication(
+  input: CreateApplicationInput,
+  signal?: AbortSignal,
+): Promise<Application> {
+  const res = await fetch(`${API_BASE_URL}/api/applications`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(input),
+    signal,
+  });
+
+  if (res.status === 409) {
+    throw new ApplicationRequestError(
+      await readMessage(res, 'You have already applied to this job.'),
+      'duplicate',
+      res.status,
+    );
+  }
+
+  if (res.status === 400) {
+    throw new ApplicationRequestError(
+      await readMessage(res, 'Missing required application details.'),
+      'invalid',
+      res.status,
+    );
+  }
+
+  if (!res.ok) {
+    throw new ApplicationRequestError(
+      await readMessage(res, 'Failed to submit application.'),
+      'request',
+      res.status,
+    );
+  }
+
+  return normalizeApplication(await res.json());
+}

--- a/src/lib/api/jobs.ts
+++ b/src/lib/api/jobs.ts
@@ -1,0 +1,97 @@
+/**
+ * Jobs API service
+ * Typed access to the job endpoints consumed by the artisan dashboard.
+ */
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+
+export type JobUrgency = 'low' | 'medium' | 'high';
+
+export type JobStatus = 'available' | 'active' | 'applied' | 'completed';
+
+/** Fields every job payload shares, regardless of its status. */
+export interface JobBase {
+  id: string;
+  title: string;
+  category: string;
+  location: string;
+}
+
+/** A job that is still open for applications. */
+export interface AvailableJob extends JobBase {
+  budget: string;
+  shortDescription: string;
+  urgency: JobUrgency;
+  icon: string;
+  status: JobStatus;
+}
+
+/** A job the artisan has already delivered. */
+export interface CompletedJob extends JobBase {
+  compensation: string;
+  completedAt: string;
+  clientName: string;
+}
+
+export type JobRecord = AvailableJob | CompletedJob;
+
+export type JobStatusFilter = 'available' | 'completed';
+
+export interface JobsQuery {
+  status?: JobStatusFilter;
+  page?: number;
+  limit?: number;
+}
+
+export interface JobsPage<TJob extends JobRecord = JobRecord> {
+  jobs: TJob[];
+  total: number;
+  page: number;
+  totalPages: number;
+}
+
+export const DEFAULT_JOBS_LIMIT = 5;
+
+/**
+ * Fetches a page of jobs.
+ * Throws an error when the request fails so callers can surface it.
+ */
+export async function fetchJobs<TJob extends JobRecord = JobRecord>(
+  query: JobsQuery = {},
+  signal?: AbortSignal,
+): Promise<JobsPage<TJob>> {
+  const { status, page = 1, limit = DEFAULT_JOBS_LIMIT } = query;
+
+  const params = new URLSearchParams({
+    page: String(page),
+    limit: String(limit),
+  });
+  if (status) {
+    params.set('status', status);
+  }
+
+  const res = await fetch(`${API_BASE_URL}/api/jobs?${params.toString()}`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    // Include credentials (cookies/session) for authenticated requests
+    credentials: 'include',
+    // Opt out of the Next.js fetch cache so listings are always fresh
+    cache: 'no-store',
+    signal,
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch jobs: ${res.status} ${res.statusText}`);
+  }
+
+  const json = (await res.json()) as Partial<JobsPage<TJob>>;
+  const jobs = Array.isArray(json.jobs) ? json.jobs : [];
+
+  return {
+    jobs,
+    total: typeof json.total === 'number' ? json.total : jobs.length,
+    page: typeof json.page === 'number' ? json.page : page,
+    totalPages:
+      typeof json.totalPages === 'number' ? Math.max(1, json.totalPages) : 1,
+  };
+}

--- a/src/lib/api/profile.ts
+++ b/src/lib/api/profile.ts
@@ -1,0 +1,102 @@
+/**
+ * Profile API service
+ * Typed access to the artisan profile endpoint.
+ */
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+
+export interface ArtisanProfile {
+  fullName: string;
+  email: string;
+  skillCategory: string;
+  state: string;
+  city: string;
+  yearsOfExperience: string;
+  bio: string;
+  profileImageUrl: string | null;
+}
+
+export const EMPTY_ARTISAN_PROFILE: ArtisanProfile = {
+  fullName: '',
+  email: '',
+  skillCategory: '',
+  state: '',
+  city: '',
+  yearsOfExperience: '',
+  bio: '',
+  profileImageUrl: null,
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+function toRecord(value: unknown): UnknownRecord {
+  return typeof value === 'object' && value !== null
+    ? (value as UnknownRecord)
+    : {};
+}
+
+function toStringValue(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+/** Fills in any field the endpoint omits so consumers never handle undefined. */
+export function normalizeArtisanProfile(raw: unknown): ArtisanProfile {
+  const record = toRecord(raw);
+
+  return {
+    fullName: toStringValue(record.fullName),
+    email: toStringValue(record.email),
+    skillCategory: toStringValue(record.skillCategory),
+    state: toStringValue(record.state),
+    city: toStringValue(record.city),
+    yearsOfExperience: toStringValue(record.yearsOfExperience),
+    bio: toStringValue(record.bio),
+    profileImageUrl:
+      typeof record.profileImageUrl === 'string' ? record.profileImageUrl : null,
+  };
+}
+
+/** Fetches the profile of the current artisan. */
+export async function fetchArtisanProfile(
+  signal?: AbortSignal,
+): Promise<ArtisanProfile> {
+  const res = await fetch(`${API_BASE_URL}/api/profile`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    cache: 'no-store',
+    signal,
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch profile: ${res.status} ${res.statusText}`);
+  }
+
+  return normalizeArtisanProfile(await res.json());
+}
+
+/** Persists a partial profile update and returns the stored profile. */
+export async function updateArtisanProfile(
+  changes: Partial<ArtisanProfile>,
+  signal?: AbortSignal,
+): Promise<ArtisanProfile> {
+  const res = await fetch(`${API_BASE_URL}/api/profile`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(changes),
+    signal,
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    const message = toRecord(body).message;
+    throw new Error(
+      typeof message === 'string' && message.trim() !== ''
+        ? message
+        : `Failed to update profile: ${res.status} ${res.statusText}`,
+    );
+  }
+
+  return normalizeArtisanProfile(await res.json());
+}

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Reusable data hooks.
+ *
+ * Every hook returns the {@link QueryResult} shape (`data`, `isLoading`,
+ * `error`, `refetch`) plus a domain alias for `data` and, where relevant, a
+ * mutation with its own `is*` and `*Error` flags.
+ */
+
+export {
+  getErrorMessage,
+  isAbortError,
+  useQuery,
+  type QueryFetcher,
+  type QueryOptions,
+  type QueryResult,
+  type UseQueryResult,
+} from './useQuery';
+
+export { useJobs, type UseJobsOptions, type UseJobsResult } from './useJobs';
+
+export {
+  useApplications,
+  type UseApplicationsOptions,
+  type UseApplicationsResult,
+} from './useApplications';
+
+export {
+  useProfile,
+  type UseProfileOptions,
+  type UseProfileResult,
+} from './useProfile';

--- a/src/lib/hooks/useApplications.ts
+++ b/src/lib/hooks/useApplications.ts
@@ -1,0 +1,93 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import {
+  createApplication as createApplicationRequest,
+  fetchApplications,
+  type Application,
+  type CreateApplicationInput,
+} from '@/lib/api/applications';
+
+import { getErrorMessage, useQuery, type QueryResult } from './useQuery';
+
+export interface UseApplicationsOptions {
+  /** Set to false to only use the mutation, e.g. on a job listing page. */
+  enabled?: boolean;
+}
+
+export interface UseApplicationsResult extends QueryResult<Application[]> {
+  /** Alias of `data` for readability at call sites. */
+  applications: Application[];
+  /**
+   * Submits an application and prepends it to the cached list.
+   * Rejects with an `ApplicationRequestError` when the endpoint refuses it.
+   */
+  createApplication: (input: CreateApplicationInput) => Promise<Application>;
+  /** True while an application is being submitted. */
+  isCreating: boolean;
+  /** Message for the last failed submission, otherwise null. */
+  createError: string | null;
+}
+
+const EMPTY_APPLICATIONS: Application[] = [];
+
+/**
+ * Loads the artisan's job applications and exposes the apply mutation.
+ *
+ * ```tsx
+ * const { applications, isLoading, error, createApplication } = useApplications();
+ * ```
+ */
+export function useApplications(
+  options: UseApplicationsOptions = {},
+): UseApplicationsResult {
+  const { enabled = true } = options;
+
+  const fetcher = useCallback(
+    (signal: AbortSignal) => fetchApplications(signal),
+    [],
+  );
+
+  const { data, isLoading, error, refetch, setData } = useQuery<Application[]>(
+    fetcher,
+    EMPTY_APPLICATIONS,
+    { enabled },
+  );
+
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const createApplication = useCallback(
+    async (input: CreateApplicationInput) => {
+      setIsCreating(true);
+      setCreateError(null);
+
+      try {
+        const application = await createApplicationRequest(input);
+        setData((current) => [
+          application,
+          ...current.filter((item) => item.id !== application.id),
+        ]);
+        return application;
+      } catch (err) {
+        setCreateError(getErrorMessage(err, 'Failed to submit application.'));
+        throw err;
+      } finally {
+        setIsCreating(false);
+      }
+    },
+    [setData],
+  );
+
+  return {
+    data,
+    applications: data,
+    isLoading,
+    error,
+    refetch,
+    createApplication,
+    isCreating,
+    createError,
+  };
+}

--- a/src/lib/hooks/useJobs.ts
+++ b/src/lib/hooks/useJobs.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import {
+  DEFAULT_JOBS_LIMIT,
+  fetchJobs,
+  type JobRecord,
+  type JobStatusFilter,
+  type JobsPage,
+} from '@/lib/api/jobs';
+
+import { useQuery, type QueryResult } from './useQuery';
+
+export interface UseJobsOptions {
+  /** Which job collection to load. Defaults to completed jobs. */
+  status?: JobStatusFilter;
+  /** Page to start on. Defaults to the first page. */
+  page?: number;
+  /** Page size. Defaults to {@link DEFAULT_JOBS_LIMIT}. */
+  limit?: number;
+  /** Set to false to skip the request. */
+  enabled?: boolean;
+}
+
+export interface UseJobsResult<TJob extends JobRecord = JobRecord>
+  extends QueryResult<TJob[]> {
+  /** Alias of `data` for readability at call sites. */
+  jobs: TJob[];
+  /** Total number of jobs across all pages. */
+  total: number;
+  /** Page currently displayed (1-based). */
+  page: number;
+  /** Number of available pages, always at least 1. */
+  totalPages: number;
+  /** Loads another page; values below 1 are clamped. */
+  setPage: (page: number) => void;
+}
+
+const EMPTY_JOBS_PAGE: JobsPage<never> = {
+  jobs: [],
+  total: 0,
+  page: 1,
+  totalPages: 1,
+};
+
+/**
+ * Loads a paginated list of jobs.
+ *
+ * ```tsx
+ * const { jobs, isLoading, error } = useJobs<AvailableJob>({ status: 'available' });
+ * ```
+ */
+export function useJobs<TJob extends JobRecord = JobRecord>(
+  options: UseJobsOptions = {},
+): UseJobsResult<TJob> {
+  const {
+    status,
+    page: initialPage = 1,
+    limit = DEFAULT_JOBS_LIMIT,
+    enabled = true,
+  } = options;
+
+  const [page, setPage] = useState(Math.max(1, initialPage));
+
+  const fetcher = useCallback(
+    (signal: AbortSignal) => fetchJobs<TJob>({ status, page, limit }, signal),
+    [status, page, limit],
+  );
+
+  const { data, isLoading, error, refetch } = useQuery<JobsPage<TJob>>(
+    fetcher,
+    EMPTY_JOBS_PAGE,
+    { enabled },
+  );
+
+  const goToPage = useCallback((next: number) => {
+    setPage(Math.max(1, Math.trunc(next)));
+  }, []);
+
+  return {
+    data: data.jobs,
+    jobs: data.jobs,
+    total: data.total,
+    page,
+    totalPages: data.totalPages,
+    setPage: goToPage,
+    isLoading,
+    error,
+    refetch,
+  };
+}

--- a/src/lib/hooks/useProfile.ts
+++ b/src/lib/hooks/useProfile.ts
@@ -1,0 +1,80 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import {
+  fetchArtisanProfile,
+  updateArtisanProfile,
+  type ArtisanProfile,
+} from '@/lib/api/profile';
+
+import { getErrorMessage, useQuery, type QueryResult } from './useQuery';
+
+export interface UseProfileOptions {
+  /** Set to false to skip the request. */
+  enabled?: boolean;
+}
+
+export interface UseProfileResult extends QueryResult<ArtisanProfile | null> {
+  /** Alias of `data`; null until the profile has loaded. */
+  profile: ArtisanProfile | null;
+  /** Persists a partial update and refreshes the cached profile. */
+  updateProfile: (changes: Partial<ArtisanProfile>) => Promise<ArtisanProfile>;
+  /** True while an update is in flight. */
+  isSaving: boolean;
+  /** Message for the last failed update, otherwise null. */
+  saveError: string | null;
+}
+
+/**
+ * Loads the artisan profile and exposes the update mutation.
+ *
+ * ```tsx
+ * const { profile, isLoading, error, updateProfile } = useProfile();
+ * ```
+ */
+export function useProfile(options: UseProfileOptions = {}): UseProfileResult {
+  const { enabled = true } = options;
+
+  const fetcher = useCallback(
+    (signal: AbortSignal) => fetchArtisanProfile(signal),
+    [],
+  );
+
+  const { data, isLoading, error, refetch, setData } = useQuery<
+    ArtisanProfile | null
+  >(fetcher, null, { enabled });
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const updateProfile = useCallback(
+    async (changes: Partial<ArtisanProfile>) => {
+      setIsSaving(true);
+      setSaveError(null);
+
+      try {
+        const updated = await updateArtisanProfile(changes);
+        setData(updated);
+        return updated;
+      } catch (err) {
+        setSaveError(getErrorMessage(err, 'Failed to update profile.'));
+        throw err;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [setData],
+  );
+
+  return {
+    data,
+    profile: data,
+    isLoading,
+    error,
+    refetch,
+    updateProfile,
+    isSaving,
+    saveError,
+  };
+}

--- a/src/lib/hooks/useQuery.ts
+++ b/src/lib/hooks/useQuery.ts
@@ -1,0 +1,129 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react';
+
+/**
+ * Shared return shape for every data hook in this folder.
+ * Hooks extend it with a domain-specific alias for `data` (for example `jobs`)
+ * so pages can destructure whichever name reads better.
+ */
+export interface QueryResult<TData> {
+  /** Latest successfully loaded value, or the hook's initial value. */
+  data: TData;
+  /** True while a request is in flight or has not run yet. */
+  isLoading: boolean;
+  /** Human-readable message for the last failed request, otherwise null. */
+  error: string | null;
+  /** Runs the request again, cancelling any in-flight one. */
+  refetch: () => void;
+}
+
+export type QueryFetcher<TData> = (signal: AbortSignal) => Promise<TData>;
+
+export interface QueryOptions {
+  /** Skip the automatic request, e.g. when a hook is only used to mutate. */
+  enabled?: boolean;
+}
+
+export interface UseQueryResult<TData> extends QueryResult<TData> {
+  /** Lets mutations keep the cached value in sync without a refetch. */
+  setData: Dispatch<SetStateAction<TData>>;
+}
+
+/** Converts any thrown value into a message that is safe to render. */
+export function getErrorMessage(
+  error: unknown,
+  fallback = 'An unexpected error occurred.',
+): string {
+  if (error instanceof Error && error.message.trim() !== '') {
+    return error.message;
+  }
+  if (typeof error === 'string' && error.trim() !== '') {
+    return error;
+  }
+  return fallback;
+}
+
+/** True when a request was cancelled rather than genuinely failing. */
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+interface SettledRequest<TData> {
+  fetcher: QueryFetcher<TData>;
+  reloadKey: number;
+}
+
+/**
+ * Minimal client-side query primitive: runs `fetcher` whenever it changes and
+ * tracks data, loading, and error state. Requests are aborted on unmount and
+ * whenever a newer request starts, so a late response never overwrites state.
+ *
+ * `fetcher` must be memoised with `useCallback`; its identity decides when the
+ * query re-runs and when the current result is considered stale.
+ */
+export function useQuery<TData>(
+  fetcher: QueryFetcher<TData>,
+  initialData: TData,
+  options: QueryOptions = {},
+): UseQueryResult<TData> {
+  const { enabled = true } = options;
+
+  const [data, setData] = useState<TData>(initialData);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [settled, setSettled] = useState<SettledRequest<TData> | null>(null);
+
+  const refetch = useCallback(() => {
+    setReloadKey((key) => key + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    void (async () => {
+      try {
+        const result = await fetcher(controller.signal);
+        if (!controller.signal.aborted) {
+          setData(result);
+          setError(null);
+        }
+      } catch (err) {
+        if (!controller.signal.aborted && !isAbortError(err)) {
+          setError(getErrorMessage(err));
+        }
+      } finally {
+        // An aborted request has already been replaced by a newer one, which
+        // reports its own outcome.
+        if (!controller.signal.aborted) {
+          setSettled({ fetcher, reloadKey });
+        }
+      }
+    })();
+
+    return () => {
+      controller.abort();
+    };
+  }, [enabled, fetcher, reloadKey]);
+
+  // A query is loading until the request for the current fetcher and reload key
+  // has settled, so pages never render data from a previous set of arguments as
+  // if it were final.
+  const isLoading =
+    enabled &&
+    (settled === null ||
+      settled.fetcher !== fetcher ||
+      settled.reloadKey !== reloadKey);
+
+  return { data, isLoading, error, refetch, setData };
+}


### PR DESCRIPTION
## Overview

Adds reusable data-loading hooks (`useJobs`, `useApplications`, `useProfile`) plus a small shared query primitive and typed API client modules, so dashboard pages stay clean and stop duplicating fetch logic. The missing `/api/profile` route is also added (it was referenced by onboarding flows but returned 404).

## Related Issue

Closes #118

## Changes

### Query hooks

- **[ADD]** `src/lib/hooks/useQuery.ts`
  - Shared `QueryResult<T>` primitive: aborts on unmount / re-run, ignores stale responses, exposes `data`, `isLoading`, `error`, `refetch`.
- **[ADD]** `src/lib/hooks/useJobs.ts`
  - `useJobs<AvailableJob>({ status: 'available' })` and `useJobs<CompletedJob>({ status: 'completed', limit })`; returns `jobs`, `total`, `page`, `totalPages`, `setPage`.
- **[ADD]** `src/lib/hooks/useApplications.ts`
  - List of applications plus a `createApplication` mutation (`isCreating` / `createError`); rejects with a typed `ApplicationRequestError` on duplicate / invalid.
- **[ADD]** `src/lib/hooks/useProfile.ts`
  - `profile` plus an `updateProfile` mutation (`isSaving` / `saveError`).
- **[ADD]** `src/lib/hooks/index.ts` — barrel export.

### API client layer

- **[ADD]** `src/lib/api/jobs.ts`, `src/lib/api/applications.ts`, `src/lib/api/profile.ts`
  - Typed `fetch*` / mutation functions (same shape as the existing `dashboard.ts`), normalising the loose application `payload` records into a single `Application` type.

### API routes

- **[ADD]** `src/app/api/profile/route.ts`
  - Cookie-backed GET / PUT / POST mock profile endpoint (mirrors `/api/preferences`); sanitises unknown fields.

### Consumers (de-duplicated fetch logic)

- **[MODIFY]** `src/app/(dashboard)/artisan/listings/(components)/JobCard.tsx`
  - Uses `useJobs` for available jobs and `useApplications.createApplication` for the Apply action (with wallet guard + per-job status feedback); client-side filtering no longer triggers a refetch.
- **[MODIFY]** `src/app/(dashboard)/artisan/listings/(components)/CompletedJobsList.tsx`
  - Uses `useJobs({ status: 'completed' })`; adds error + retry state.
- **[MODIFY]** `src/app/(dashboard)/artisan/listings/(components)/AppliedJobsList.tsx`
  - Uses `useApplications`; now renders real data (was permanently empty due to an API-shape mismatch).
- **[MODIFY]** `src/app/(dashboard)/artisan/profile/page.tsx`
  - Uses `useProfile`; loads and persists the form via the API instead of a mocked `setTimeout`.

## Verification Results

```
pnpm lint      -> clean
pnpm build     -> clean (Next.js build + TypeScript); /api/profile present in route table

Runtime (Chromium, dev server):
- Available tab renders 5 jobs; loading indicator shows while pending
- Applied tab now renders submitted applications
- Completed tab paginates (Page 1 -> 2)
- Apply without wallet -> "Connect your wallet to apply."
- Profile loads, saves, and persists after reload
- Forced 500 -> error state with "Try again" recovers
- Filtering triggers no extra request (no fetch loops)
- No console errors
```

## Acceptance Criteria

| Criterion | Status |
| --- | --- |
| At least 3 pages consume shared hooks | ✅ `/artisan/jobs` + `/artisan/listings` (JobCard, CompletedJobsList, AppliedJobsList) and `/artisan/profile` |
| Hooks expose predictable typed return shapes | ✅ shared `QueryResult<T>` + domain aliases |
