### PR TITLE
feat(frontend): add global toast and form status system

### DIFF
--- a/src/app/(auth)/profile-setup/artisan-step2/page.tsx
+++ b/src/app/(auth)/profile-setup/artisan-step2/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { useOnboarding } from '@/components/artisan/onboarding-context';
 import type { ArtisanFormData } from '@/components/artisan/onboarding-context';
 import { ArtisanProfileStep2 } from '@/components/artisan/artisan-profile-step2';
 import { OnboardingStepHeader } from '@/components/artisan/onboarding-step-header';
+import { useFormSubmission } from '@/hooks/use-form-submission';
 
 export default function ArtisanStep2() {
   const router = useRouter();
@@ -18,7 +19,10 @@ export default function ArtisanStep2() {
     completed,
     isHydrated,
   } = useOnboarding();
-  const [isLoading, setIsLoading] = useState(false);
+  const { isPending: isLoading, submit } = useFormSubmission({
+    errorMessage: (error) =>
+      error instanceof Error ? error.message : 'Failed to save profile data.',
+  });
 
   useEffect(() => {
     if (!isHydrated) return;
@@ -42,9 +46,8 @@ export default function ArtisanStep2() {
 
     const updatedArtisanData = { ...artisanData, ...data };
     setArtisanData(updatedArtisanData);
-    setIsLoading(true);
 
-    try {
+    await submit(async () => {
       const response = await fetch('/api/profile', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -58,11 +61,7 @@ export default function ArtisanStep2() {
 
       completeOnboarding();
       router.push('/profile-setup/success');
-    } catch (error) {
-      console.error('Error saving profile data:', error);
-    } finally {
-      setIsLoading(false);
-    }
+    });
   };
 
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import { WalletProvider } from "../context/WalletProvider";
 import { AuthProvider } from "../context/AuthProvider";
+import { ToastProvider } from "../context/ToastProvider";
 
 const satoshi = localFont({
   src: [
@@ -43,9 +44,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${satoshi.variable} antialiased`}>
-        <WalletProvider>
-          <AuthProvider>{children}</AuthProvider>
-        </WalletProvider>
+        <ToastProvider>
+          <WalletProvider>
+            <AuthProvider>{children}</AuthProvider>
+          </WalletProvider>
+        </ToastProvider>
       </body>
     </html>
   );

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { CheckCircle2, Info, Loader2, X, XCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ToastItem } from "@/context/ToastProvider";
+
+const VARIANT_STYLES: Record<ToastItem["variant"], string> = {
+  success: "border-green-200 bg-green-50 text-green-900",
+  error: "border-red-200 bg-red-50 text-red-900",
+  info: "border-gray-200 bg-white text-gray-900",
+  loading: "border-gray-200 bg-white text-gray-900",
+};
+
+const VARIANT_ICON: Record<ToastItem["variant"], React.ReactNode> = {
+  success: <CheckCircle2 className="size-5 shrink-0 text-green-600" />,
+  error: <XCircle className="size-5 shrink-0 text-red-600" />,
+  info: <Info className="size-5 shrink-0 text-gray-500" />,
+  loading: <Loader2 className="size-5 shrink-0 animate-spin text-gray-500" />,
+};
+
+interface ToastViewportProps {
+  toasts: ToastItem[];
+  onDismiss: (id: string) => void;
+}
+
+export function ToastViewport({ toasts, onDismiss }: ToastViewportProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label="Notifications"
+      className="pointer-events-none fixed inset-x-0 top-4 z-[100] flex flex-col items-center gap-2 px-4 sm:inset-x-auto sm:right-4 sm:items-end"
+    >
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          role={toast.variant === "error" ? "alert" : "status"}
+          aria-live={toast.variant === "error" ? "assertive" : "polite"}
+          className={cn(
+            "pointer-events-auto flex w-full max-w-sm items-start gap-3 rounded-lg border p-4 shadow-lg transition-all",
+            VARIANT_STYLES[toast.variant],
+          )}
+        >
+          {VARIANT_ICON[toast.variant]}
+          <div className="min-w-0 flex-1">
+            {toast.title && <p className="text-sm font-semibold">{toast.title}</p>}
+            {toast.description && (
+              <p className="text-sm opacity-90">{toast.description}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => onDismiss(toast.id)}
+            aria-label="Dismiss notification"
+            className="shrink-0 rounded-md p-1 opacity-60 transition-opacity hover:opacity-100"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/context/ToastProvider.tsx
+++ b/src/context/ToastProvider.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import { ToastViewport } from "@/components/ui/toast";
+
+export type ToastVariant = "success" | "error" | "info" | "loading";
+
+export interface ToastItem {
+  id: string;
+  variant: ToastVariant;
+  title?: string;
+  description?: string;
+}
+
+export interface ToastOptions {
+  title?: string;
+  description?: string;
+  /** Milliseconds before auto-dismiss. Pass 0 to require manual dismissal. */
+  duration?: number;
+}
+
+interface ToastContextValue {
+  toasts: ToastItem[];
+  show: (variant: ToastVariant, options: ToastOptions) => string;
+  dismiss: (id: string) => void;
+}
+
+const DEFAULT_DURATION: Record<ToastVariant, number> = {
+  success: 4000,
+  info: 4000,
+  error: 6000,
+  loading: 0,
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+    const timer = timers.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timers.current.delete(id);
+    }
+  }, []);
+
+  const show = useCallback(
+    (variant: ToastVariant, options: ToastOptions) => {
+      const id = crypto.randomUUID();
+      setToasts((current) => [...current, { id, variant, ...options }]);
+
+      const duration = options.duration ?? DEFAULT_DURATION[variant];
+      if (duration > 0) {
+        const timer = setTimeout(() => dismiss(id), duration);
+        timers.current.set(id, timer);
+      }
+
+      return id;
+    },
+    [dismiss],
+  );
+
+  const value = useMemo(() => ({ toasts, show, dismiss }), [toasts, show, dismiss]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastViewport toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+function useToastContext(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return ctx;
+}
+
+/**
+ * Global toast hook. Wrap the app once in <ToastProvider> (see app/layout.tsx),
+ * then call these from anywhere — form handlers, wallet actions, etc. — for
+ * consistent action-outcome feedback.
+ */
+export function useToast() {
+  const { show, dismiss } = useToastContext();
+
+  return useMemo(
+    () => ({
+      success: (description: string, options?: Omit<ToastOptions, "description">) =>
+        show("success", { ...options, description }),
+      error: (description: string, options?: Omit<ToastOptions, "description">) =>
+        show("error", { ...options, description }),
+      info: (description: string, options?: Omit<ToastOptions, "description">) =>
+        show("info", { ...options, description }),
+      loading: (description: string, options?: Omit<ToastOptions, "description">) =>
+        show("loading", { ...options, description }),
+      dismiss,
+    }),
+    [show, dismiss],
+  );
+}

--- a/src/hooks/use-form-submission.ts
+++ b/src/hooks/use-form-submission.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useToast } from "@/context/ToastProvider";
+
+export type SubmitStatus = "idle" | "pending" | "success" | "error";
+
+interface UseFormSubmissionOptions<T> {
+  /** Shown via the global toast on success. Omit to suppress the success toast. */
+  successMessage?: string | ((result: T) => string);
+  /** Shown via the global toast on failure. Defaults to the thrown error's message. */
+  errorMessage?: string | ((error: unknown) => string);
+  onSuccess?: (result: T) => void;
+  onError?: (error: unknown) => void;
+}
+
+interface UseFormSubmissionResult<T> {
+  status: SubmitStatus;
+  isPending: boolean;
+  error: string | null;
+  /** Runs the action, tracking pending/success/error status and firing toasts. */
+  submit: (action: () => Promise<T>) => Promise<T | undefined>;
+  reset: () => void;
+}
+
+/**
+ * Standardizes the pending/success/error lifecycle for form and action
+ * submissions across the app, and surfaces outcomes via the global toast
+ * system so every form gets consistent feedback for free.
+ */
+export function useFormSubmission<T = void>(
+  options: UseFormSubmissionOptions<T> = {},
+): UseFormSubmissionResult<T> {
+  const { successMessage, errorMessage, onSuccess, onError } = options;
+  const toast = useToast();
+  const [status, setStatus] = useState<SubmitStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setStatus("idle");
+    setError(null);
+  }, []);
+
+  const submit = useCallback(
+    async (action: () => Promise<T>) => {
+      setStatus("pending");
+      setError(null);
+
+      try {
+        const result = await action();
+        setStatus("success");
+
+        if (successMessage) {
+          toast.success(
+            typeof successMessage === "function" ? successMessage(result) : successMessage,
+          );
+        }
+        onSuccess?.(result);
+        return result;
+      } catch (err) {
+        const message =
+          typeof errorMessage === "function"
+            ? errorMessage(err)
+            : errorMessage ?? (err instanceof Error ? err.message : "Something went wrong. Please try again.");
+
+        setStatus("error");
+        setError(message);
+        toast.error(message);
+        onError?.(err);
+        return undefined;
+      }
+    },
+    [toast, successMessage, errorMessage, onSuccess, onError],
+  );
+
+  return { status, isPending: status === "pending", error, submit, reset };
+}


### PR DESCRIPTION
# 🚀 Artisyn.io Pull Request

- [x] Closes #116
- [ ] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting
- [ ] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [x] Enhancement (non-breaking change which adds functionality)

---

## 📝 Changes description

- `src/context/ToastProvider.tsx`: global `ToastProvider` + `useToast()` hook (`success` / `error` / `info` / `loading`, each with sensible auto-dismiss durations). Mounted once in `src/app/layout.tsx` alongside the existing `WalletProvider`/`AuthProvider`, rendering a fixed viewport so any component can call `useToast()`.
- `src/components/ui/toast.tsx`: the visual toast viewport/item used by the provider.
- `src/hooks/use-form-submission.ts`: a shared `useFormSubmission` hook standardizing the `idle` → `pending` → `success` / `error` lifecycle for form and action submissions, firing the matching toast automatically (with optional custom success/error messages).
- Migrated `src/app/(auth)/profile-setup/artisan-step2/page.tsx` onto the new hook as a reference usage — its submit handler previously swallowed save failures with only a `console.error` and gave the user no feedback at all; it now surfaces failures via toast and tracks pending state consistently.

## Acceptance Criteria
- [x] Toasts appear for key action outcomes (wired into the onboarding save-profile flow; available globally via `useToast()`).
- [x] Form components follow a consistent submit status pattern (`useFormSubmission`).

Note: `src/app/(dashboard)/artisan/settings/page.tsx` already grew its own local toast/status implementation in a separate recent PR (linked accounts, notification prefs, privacy, blocklist) — didn't touch it here to avoid clobbering that work; it's a good follow-up candidate to migrate onto this shared system.

---

## 📸 Evidence (A photo is required as evidence)

No live environment available in this session to capture a screenshot/GIF — happy to add one, or a maintainer can verify by running `pnpm dev` and triggering the save action on `/profile-setup/artisan-step2`.

---

Thank you for contributing to Artisyn.io, we are glad that you have chosen us as your project of choice and we hope that you continue to contribute to this great project, so that together we can make our mark at the top!